### PR TITLE
Update completeconfig to fix crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     modImplementation include("net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}")
 
-    modImplementation include("com.github.Lortseam.completeconfig:base:2.5.1")
+    modImplementation include("com.github.Lortseam.completeconfig:base:2.5.2")
     modImplementation include("eu.pb4:placeholder-api:2.2.0+1.20.2")
 
     // External libraries to bundle with JAR


### PR DESCRIPTION
In completeconfig 2.5.2 a bug was fixed that would lead to the server crashing on start with Fabric Loader v0.15.0. That would also happen to f2d because of the dependency.
This PR updates cc to the latest version to fix that. [completeconfig 2.5.2](https://github.com/Lortseam/completeconfig/releases/tag/2.5.2)

Also mentioned in the 2.5.2 release is that completeconfig is deprecated and will not get updated for 1.21, so keep that in mind.